### PR TITLE
fix: align top to right when nav button is disabled

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -56,12 +56,12 @@
                   {{ end }}
                   {{ end }}
                 </ul>
-        
+                
+                {{ if site.Params.navigation_button.enable }}
                 <div class="navbar-right">
-                  {{ if site.Params.navigation_button.enable }}
                   <a href="{{ site.Params.navigation_button.link | relURL }}" class="btn btn-primary">{{ site.Params.navigation_button.label }}</a>
-                  {{ end }}
                 </div>
+                {{ end }}
               </div>
           </nav>
         </div>


### PR DESCRIPTION
When the navigation button is disabled, the menu is stuck in the
middle while there is extra empty white space in the right. This
is due to the flex with 2 divs spacing. The div is now hidden when the
navigation button is disabled.